### PR TITLE
Fix: Resolve Makefile shell syntax errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Set shell to bash explicitly for bash-specific syntax
+SHELL := /bin/bash
+
 .PHONY: help setup-hooks new-feature new-bugfix finish-feature status check-workflow
 
 help: ## Show this help message


### PR DESCRIPTION
- Add explicit SHELL := /bin/bash to Makefile to support bash-specific syntax
- Fix regex matching ([[ =~ ]]) that was causing 'Syntax error: "(" unexpected'
- Maintain all existing functionality while ensuring compatibility
- Enables proper branch validation in finish-feature command

This resolves the issue where 'make finish-feature' was failing with
shell syntax errors due to bash constructs in POSIX sh context.

## Description
Brief description of what this PR does.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧪 Test-related changes
- [x] 🔧 Build/CI changes

## Testing
- [x] Tests pass locally
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] Manual testing completed (if applicable)

## Coverage
- [ ] Code coverage maintained or improved
- [x] No coverage regressions introduced

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Related Issues
Closes #(issue number)
