### PR TITLE
Add CD: automated deploy on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,38 @@ jobs:
       continue-on-error: true
       with:
         sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    runs-on: self-hosted
+    needs: [test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+    - name: Pull latest code
+      working-directory: /var/www/andrew/andrewhermann
+      run: git pull
+
+    - name: Install dependencies
+      working-directory: /var/www/andrew/andrewhermann
+      run: npm install
+
+    - name: Regenerate sitemap
+      working-directory: /var/www/andrew/andrewhermann
+      run: npm run seo:sitemap
+
+    - name: Build frontend
+      working-directory: /var/www/andrew/andrewhermann
+      run: npm run build
+
+    - name: Restart frontend
+      run: pm2 restart frontend
+
+    - name: Restart backend if backend code changed
+      working-directory: /var/www/andrew/andrewhermann
+      run: |
+        if git diff HEAD~1 --name-only | grep -qE '^backend/'; then
+          echo "Backend files changed — restarting backend-api"
+          pm2 restart backend-api
+        else
+          echo "No backend changes — skipping backend restart"
+        fi


### PR DESCRIPTION
## Summary
- Adds a `deploy` job to `ci.yml` that runs on the self-hosted runner (`hermannshub`) after all tests pass
- Only fires on push to `main` (i.e. after a PR is merged) — never on PRs themselves
- Runs the standard deploy sequence: `git pull` → `npm install` → `npm run seo:sitemap` → `npm run build` → `pm2 restart frontend`
- Conditionally restarts `backend-api` only when files under `backend/` changed in the merge

## Test plan
- [ ] Merge this PR and watch the Actions tab — deploy job should appear and go green
- [ ] Confirm site is live and up to date after the deploy job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)