### PR TITLE
ci: harden CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
       run: npm test -- --coverage --watchAll=false --ci --verbose
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       if: matrix.node-version == '22.x'
       with:
         file: ./coverage/lcov.info
@@ -70,7 +70,7 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       continue-on-error: true
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
@@ -59,7 +59,7 @@ jobs:
       security-events: write
       actions: read
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@v0.35.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
-      if: matrix.node-version == '20.x'
+      if: matrix.node-version == '22.x'
       with:
         file: ./coverage/lcov.info
         fail_ci_if_error: false
@@ -44,10 +44,10 @@ jobs:
 
     - name: Check for critical security vulnerabilities
       run: |
-        # Allow dev-only vulnerabilities, only fail on production-critical issues
-        npm audit --omit=dev --audit-level=critical || echo "::warning::Development dependencies have non-critical vulnerabilities"
+        # Fail the build if any production dependency has a critical vulnerability
+        npm audit --omit=dev --audit-level=critical
 
-        # Run full audit for reporting but don't fail build
+        # Report high and above for visibility, but don't fail
         echo "::group::Full Security Audit Report"
         npm audit --audit-level=high || echo "Non-critical vulnerabilities found (see dependency management issue #26)"
         echo "::endgroup::"
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'
@@ -78,7 +78,7 @@ jobs:
 
   deploy:
     runs-on: self-hosted
-    needs: [test]
+    needs: [test, security-check]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
@@ -104,9 +104,24 @@ jobs:
     - name: Restart backend if backend code changed
       working-directory: /var/www/andrew/andrewhermann
       run: |
-        if git diff HEAD~1 --name-only | grep -qE '^backend/'; then
+        if git log -1 --name-only --format="" | grep -qE '^backend/'; then
           echo "Backend files changed — restarting backend-api"
           pm2 restart backend-api
         else
           echo "No backend changes — skipping backend restart"
         fi
+
+    - name: Health check
+      run: |
+        echo "Waiting for frontend to come up..."
+        sleep 5
+        for i in 1 2 3; do
+          if curl -fsS --max-time 10 https://andrew.cloudhopper.ch > /dev/null; then
+            echo "Health check passed"
+            exit 0
+          fi
+          echo "Attempt $i failed, retrying in 5s..."
+          sleep 5
+        done
+        echo "Health check failed after 3 attempts — deploy may be broken"
+        exit 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -35,7 +35,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
@@ -42,9 +42,9 @@ jobs:
       run: npm ci --legacy-peer-deps
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,8 +11,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v6
+
     - name: Auto-label PR
       uses: actions/labeler@v6
       with:
@@ -20,7 +20,7 @@ jobs:
         configuration-path: .github/labeler.yml
 
     - name: Add size labels
-      uses: pascalgn/size-label-action@v0.4.3
+      uses: pascalgn/size-label-action@v0.5.7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/src/__tests__/components/footer.test.js
+++ b/src/__tests__/components/footer.test.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { screen } from '@testing-library/react';
 import { renderWithRouter } from '../../testUtils';
 import Footer from '../../components/footer';
 

--- a/src/components/FloatingRobot.js
+++ b/src/components/FloatingRobot.js
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import ThreeScene from './ThreeScene';
 import './FloatingRobot.css';
 

--- a/src/components/Robot.js
+++ b/src/components/Robot.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useLayoutEffect, Suspense, useState, useEffect } from 'react';
+import { useRef, useLayoutEffect, Suspense, useState, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useGLTF, useAnimations } from '@react-three/drei';
 import * as THREE from 'three';
@@ -46,7 +46,7 @@ const Robot = () => {
   const { actions, mixer } = useAnimations(animations, group);
   
   // State for interactive controls
-  const [currentAnimation, setCurrentAnimation] = useState('Idle');
+  const [, setCurrentAnimation] = useState('Idle');
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
   const [rotation, setRotation] = useState({ x: 0, y: Math.PI }); // Face forward

--- a/src/components/ThreeScene.js
+++ b/src/components/ThreeScene.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import SafeRobot from './Robot';
@@ -67,7 +67,7 @@ const InteractiveCameraController = () => {
 };
 
 const ThreeScene = () => {
-  const [useRobot, setUseRobot] = useState(true);
+  const [useRobot] = useState(true);
   
   return (
     <Canvas

--- a/src/components/features2.js
+++ b/src/components/features2.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import PropTypes from 'prop-types'
 

--- a/src/components/pricing.js
+++ b/src/components/pricing.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import PropTypes from 'prop-types'
 

--- a/src/components/testimonial.js
+++ b/src/components/testimonial.js
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React from 'react'
-
 import PropTypes from 'prop-types'
 
 import './testimonial.css'


### PR DESCRIPTION
## Summary
- Drop EOL Node 18.x, add Node 22.x to test matrix
- Pin Trivy action to `v0.35.0` (was `@master`, unpinned)
- Gate `deploy` on both `test` and `security-check` passing
- Make `npm audit --audit-level=critical` a hard failure for prod deps (was silenced with `|| echo`)
- Fix backend change detection: use `git log -1` instead of fragile `git diff HEAD~1`
- Add post-deploy health check with 3 retries against `https://andrew.cloudhopper.ch`

## Test plan
- [ ] CI runs pass on both Node 20.x and 22.x
- [ ] Trivy scan completes with pinned version
- [ ] Deploy job shows as blocked by security-check (verify in Actions tab after merge)
- [ ] Health check step appears in deploy job log on next production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)